### PR TITLE
서버 자동배포

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -5,5 +5,6 @@ COPY package*.json ./
 
 RUN yarn
 COPY . .
+RUN npx prisma generate
 
 CMD ["yarn", "start:ts-node"]

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -13,6 +13,6 @@ const server = new GraphQLServer({
 });
 server.express.use(logger('dev'));
 
-server.start({ port: PORT }, () =>
+server.start({ port: PORT, endpoint: '/graphql', playground: '/graphql' }, () =>
   console.log(`Server is running on http://localhost:${PORT}`)
 );

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -5,7 +5,7 @@ import logger from 'morgan';
 import '../env';
 const prisma = new PrismaClient();
 
-const PORT = process.env.PORT;
+const PORT = process.env.PORT || 3000;
 
 const server = new GraphQLServer({
   typeDefs,


### PR DESCRIPTION
## 설명
- Change graphql endpoint to `/graphql`
- Build prisma while building appserver docker image
- Set default server port

## 관련 이슈
- resolved #28 
- resolved #35 