### PR TITLE
주문내역, 찜 컴포넌트 생성, second category 닫힘 이벤트

### DIFF
--- a/client/src/components/ArrowBack.tsx
+++ b/client/src/components/ArrowBack.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import styled from 'styled-components';
+import ArrowBackIcon from '@material-ui/icons/ArrowBack';
+
+const ArrowBackBlock = styled.div`
+  background-color: white;
+`;
+
+type ArrowBackProps = {
+  className: string;
+};
+const ArrowBack: React.FC<ArrowBackProps> = ({ className }: any) => {
+  return (
+    <ArrowBackBlock>
+      <ArrowBackIcon></ArrowBackIcon>
+    </ArrowBackBlock>
+  );
+};
+export default ArrowBack;

--- a/client/src/components/ArrowFront.tsx
+++ b/client/src/components/ArrowFront.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import styled from 'styled-components';
+import KeyboardArrowRightIcon from '@material-ui/icons/KeyboardArrowRight';
+
+const ArrowFrontBlock = styled.div`
+  background-color: white;
+  color: gray;
+`;
+
+type ArrowFrontProps = {};
+const ArrowFront: React.FC<ArrowFrontProps> = () => {
+  return (
+    <ArrowFrontBlock>
+      <KeyboardArrowRightIcon></KeyboardArrowRightIcon>
+    </ArrowFrontBlock>
+  );
+};
+export default ArrowFront;

--- a/client/src/components/ArrowFront.tsx
+++ b/client/src/components/ArrowFront.tsx
@@ -3,8 +3,10 @@ import styled from 'styled-components';
 import KeyboardArrowRightIcon from '@material-ui/icons/KeyboardArrowRight';
 
 const ArrowFrontBlock = styled.div`
+  position: relative;
   background-color: white;
   color: gray;
+  top:-0.2rem;
 `;
 
 type ArrowFrontProps = {};

--- a/client/src/components/category/CategoryContent.js
+++ b/client/src/components/category/CategoryContent.js
@@ -15,11 +15,11 @@ const CategoryContentBlock = styled.div`
 
   .active {
     font-weight: bold;
-    background-color: ${palette.gray100};
+    background-color: ${palette.gray200};
   }
 
   .third {
-    background-color: ${palette.gray100};
+    background-color: ${palette.gray200};
   }
 
   .second > div,

--- a/client/src/components/category/CategoryContent.js
+++ b/client/src/components/category/CategoryContent.js
@@ -41,7 +41,12 @@ function CategoryContent(props) {
   const [selected, setSelected] = useState(false);
   const [showThird, setShowThird] = useState(false);
 
+  props.setCloseCallback(() => {
+    setShowThird(false);
+  });
+
   function toggleThirdCategory(index) {
+    props.closeAllContent();
     if (showThird && selected === index) {
       setShowThird(false);
     } else {

--- a/client/src/components/category/CategoryContent.js
+++ b/client/src/components/category/CategoryContent.js
@@ -41,15 +41,16 @@ function CategoryContent(props) {
   const [selected, setSelected] = useState(false);
   const [showThird, setShowThird] = useState(false);
 
-  props.setCloseCallback(() => {
-    setShowThird(false);
-  });
+ 
 
   function toggleThirdCategory(index) {
-    props.closeAllContent();
+    props.closeContent();
     if (showThird && selected === index) {
       setShowThird(false);
     } else {
+      props.setCloseCallback(() => {
+        setShowThird(false);
+      });
       setShowThird(true);
     }
     setSelected(index);

--- a/client/src/components/category/CategoryContent.js
+++ b/client/src/components/category/CategoryContent.js
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 
 import { gql } from 'apollo-boost';
 import { Query } from 'react-apollo';
-import palette from '../lib/styles/palette';
+import palette from '../../lib/styles/palette';
 
 const CategoryContentBlock = styled.div`
   .second,

--- a/client/src/components/category/CategoryTitle.js
+++ b/client/src/components/category/CategoryTitle.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
-import palette from '../lib/styles/palette';
+import palette from '../../lib/styles/palette';
 
 const CategoryTitleBlock = styled.div`
   padding-top: 1rem;

--- a/client/src/components/category/Dibs.js
+++ b/client/src/components/category/Dibs.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import styled from 'styled-components';
+import palette from '../../lib/styles/palette';
+import FavoriteIcon from '@material-ui/icons/Favorite';
+
+const DibsBlock = styled.div`
+  font-size: 0.8rem;
+  padding: 0.6rem;
+  width: 12rem;
+  box-sizing: border-box;
+  border-right: solid 0.1rem ${palette.gray300};
+  border-top: solid 0.1rem ${palette.gray300};
+  border-bottom: solid 0.1rem ${palette.gray300};
+  background-color: white;
+  text-align: center;
+`;
+
+function Dibs() {
+  return (
+    <DibsBlock>
+      <FavoriteIcon style={{ color: 'red' }}></FavoriteIcon>
+      <div>찜한상품</div>
+    </DibsBlock>
+  );
+}
+
+export default Dibs;

--- a/client/src/components/category/GoBmart.js
+++ b/client/src/components/category/GoBmart.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import styled from 'styled-components';
+import ArrowFront from '../ArrowFront';
+import { Link } from 'react-router-dom';
+
+const GoBmartBlock = styled.div`
+  padding-top: 2rem;
+  padding-left: 1rem;
+  background-color: white;
+  cursor: pointer;
+
+  div {
+    display: flex;
+  }
+`;
+
+function GoBmart() {
+  return (
+    <GoBmartBlock>
+      <Link style={{ textDecoration: 'none', color: 'black' }} to="/">
+        <div>
+          <span style={{ fontWeight: 'bold' }}>B마트 홈</span>
+          <span>으로 가기</span>
+          <ArrowFront></ArrowFront>
+        </div>
+      </Link>
+    </GoBmartBlock>
+  );
+}
+
+export default GoBmart;

--- a/client/src/components/category/OrderList.js
+++ b/client/src/components/category/OrderList.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import styled from 'styled-components';
+import palette from '../../lib/styles/palette';
+import FormatListBulletedIcon from '@material-ui/icons/FormatListBulleted';
+
+const OrderListBlock = styled.div`
+  font-size: 0.8rem;
+  padding: 0.6rem;
+  width: 12rem;
+  box-sizing: border-box;
+  border: solid 0.1rem ${palette.gray300};
+  background-color: white;
+  text-align: center;
+`;
+
+function OrderList() {
+  return (
+    <OrderListBlock>
+      <FormatListBulletedIcon></FormatListBulletedIcon>
+      <div>주문내역</div>
+    </OrderListBlock>
+  );
+}
+
+export default OrderList;

--- a/client/src/lib/styles/palette.ts
+++ b/client/src/lib/styles/palette.ts
@@ -9,7 +9,7 @@ const palette = {
   baemint200: '#87d9d6',
   baemint100: 'rgba(135,217,214,0.5)',
   gray100: '#fafbfc',
-  gray200: '#eff1f3',
+  gray200: '#f4f4f4',
   gray300: '#e1e4e8',
   gray400: 'rgba(209, 213, 218, 0.5)',
   gray500: '#586069',

--- a/client/src/pages/CategoryPage.js
+++ b/client/src/pages/CategoryPage.js
@@ -49,6 +49,16 @@ const CategoryPageBlock = styled.div`
   }
 `;
 function CategoryPage() {
+  let closeCallbackList = [];
+  function closeAllContent() {
+    for (const cb of closeCallbackList) {
+      cb();
+    }
+  }
+  function setCloseCallback(cb) {
+    closeCallbackList.push(cb);
+  }
+
   return (
     <CategoryPageBlock>
       <div className="back">
@@ -70,9 +80,13 @@ function CategoryPage() {
               const left = firstCategory.children[i];
               const right = firstCategory.children[i + 1];
               childList.push(
-                <CategoryContent data={[left, right]}></CategoryContent>
+                <CategoryContent
+                  setCloseCallback={setCloseCallback}
+                  closeAllContent={closeAllContent}
+                  data={[left, right]}></CategoryContent>
               );
             }
+
             categoryList.push(
               <div className="Category">
                 <CategoryTitle title={firstCategory.name}></CategoryTitle>

--- a/client/src/pages/CategoryPage.js
+++ b/client/src/pages/CategoryPage.js
@@ -49,14 +49,13 @@ const CategoryPageBlock = styled.div`
   }
 `;
 function CategoryPage() {
-  let closeCallbackList = [];
-  function closeAllContent() {
-    for (const cb of closeCallbackList) {
-      cb();
-    }
+  let selectedClose;
+  function closeContent() {
+    if (!selectedClose) return;
+    selectedClose();
   }
   function setCloseCallback(cb) {
-    closeCallbackList.push(cb);
+    selectedClose = cb;
   }
 
   return (
@@ -82,7 +81,7 @@ function CategoryPage() {
               childList.push(
                 <CategoryContent
                   setCloseCallback={setCloseCallback}
-                  closeAllContent={closeAllContent}
+                  closeContent={closeContent}
                   data={[left, right]}></CategoryContent>
               );
             }

--- a/client/src/pages/CategoryPage.js
+++ b/client/src/pages/CategoryPage.js
@@ -5,8 +5,12 @@ import palette from '../lib/styles/palette';
 import { gql } from 'apollo-boost';
 import { Query } from 'react-apollo';
 
-import CategoryContent from '../components/CategoryContent';
-import CategoryTitle from '../components/CategoryTitle';
+import GoBmart from '../components/category/GoBmart';
+import CategoryContent from '../components/category/CategoryContent';
+import CategoryTitle from '../components/category/CategoryTitle';
+import Dibs from '../components/category/Dibs';
+import ArrowBack from '../components/ArrowBack';
+import OrderList from '../components/category/OrderList';
 
 const GetFirstCategory = gql`
   query {
@@ -23,15 +27,38 @@ const GetFirstCategory = gql`
 const CategoryPageBlock = styled.div`
   text-align: left;
   background-color: ${palette.gray300};
+
+  .back {
+    padding-top: 1rem;
+    padding-left: 1rem;
+    background-color: white;
+  }
+
   .Category {
     border-bottom: 0.1rem solid ${palette.gray400};
     background-color: ${palette.white};
     margin-top: 0.1rem;
   }
+
+  .other {
+    padding-top: 1.5rem;
+    padding-bottom: 1.5rem;
+    display: flex;
+    justify-content: center;
+    background-color: white;
+  }
 `;
 function CategoryPage() {
   return (
     <CategoryPageBlock>
+      <div className="back">
+        <ArrowBack></ArrowBack>
+      </div>
+      <GoBmart></GoBmart>
+      <div className="other">
+        <OrderList></OrderList>
+        <Dibs></Dibs>
+      </div>
       <Query query={GetFirstCategory}>
         {({ data, loading, error }) => {
           if (loading) return '';


### PR DESCRIPTION
## 설명
- 카테고리 페이지 스타일링(주문내역, 찜 컴포넌트 생성)
- second category 선택 후 다른 카테고리 선택 시, 전에 선택된 카테고리를 no-sohw로 바꿔줌
- state는 안쓰고 있어요. 부모하고 자식 컴포넌트간 통신을 어떻게 해야할지 모르겠습니다.... ㅠㅠ

## 관련 이슈
- resolved #54 

## 기타(스크린샷 등)
![image](https://user-images.githubusercontent.com/38103082/90536655-4fa99500-e1b7-11ea-9d52-9c1de9b35860.png)
![image](https://user-images.githubusercontent.com/38103082/90536677-56d0a300-e1b7-11ea-8ed5-659be3ffaf30.png)
![image](https://user-images.githubusercontent.com/38103082/90536686-5b955700-e1b7-11ea-92e3-f8142055060a.png)
