### PR TITLE
캐로셀 타이밍 이슈 수정/ 리팩터

### DIFF
--- a/client/src/components/Carousel/Carousel.tsx
+++ b/client/src/components/Carousel/Carousel.tsx
@@ -62,6 +62,8 @@ const Carousel: React.FC<CarouselProps> = ({ images, transitionTime }) => {
   const [timeoutId, setTimeoutId] = useState<number | null>(null);
 
   // 마우스로 화면을 눌렀을 때의 X좌표
+  // Remove transition animation if not null.
+  // Therefore also be used to disable animation in edge cases.
   const [startX, setStartX] = useState<number | null>(1);
 
   // offsetIdx번째 아이템에서 dx만큼 더 translate
@@ -74,12 +76,12 @@ const Carousel: React.FC<CarouselProps> = ({ images, transitionTime }) => {
     )}px)`;
   };
 
-  const moveBanner = (idx: number) => {
+  const moveBanner = (idx: number, instantMove: boolean = false) => {
     if (idx === 0) {
       setTimeout(() => {
         // To remove transition animation
         setStartX(1);
-        moveBanner(images.length);
+        moveBanner(images.length, true);
         (window as any).requestIdleCallback(() => {
           setStartX(null);
         });
@@ -87,7 +89,7 @@ const Carousel: React.FC<CarouselProps> = ({ images, transitionTime }) => {
     } else if (idx === images.length + 1) {
       setTimeout(() => {
         setStartX(1);
-        moveBanner(1);
+        moveBanner(1, true);
         (window as any).requestIdleCallback(() => {
           setStartX(null);
         });
@@ -100,15 +102,20 @@ const Carousel: React.FC<CarouselProps> = ({ images, transitionTime }) => {
       setTimeoutId(null);
     }
 
-    // To set indicator
-    setCurBannerIdx(idx);
-    if (idx > 0 && idx < images.length + 1) {
-      const newTimeoutId = setTimeout(
-        () => moveBanner(idx + 1),
-        transitionTime
-      );
-      setTimeoutId(newTimeoutId);
-    }
+    setTimeout(
+      () => {
+        // To update indicator
+        setCurBannerIdx(idx);
+        if (idx > 0 && idx < images.length + 1) {
+          const newTimeoutId = setTimeout(
+            () => moveBanner(idx + 1),
+            transitionTime
+          );
+          setTimeoutId(newTimeoutId);
+        }
+      },
+      instantMove ? 0 : cssTransitionTime
+    );
   };
 
   useEffect(() => {

--- a/client/src/components/Carousel/Carousel.tsx
+++ b/client/src/components/Carousel/Carousel.tsx
@@ -56,6 +56,7 @@ type CarouselProps = {
 const Carousel: React.FC<CarouselProps> = ({ images, transitionTime }) => {
   // to get width of the container
   const containerRef = useRef(null);
+  const cssTransitionTime = Math.min(transitionTime / 3, 400);
   const [curBanner, setCurBanner] = useState(1);
   const [timeoutId, setTimeoutId] = useState<number | null>(null);
 
@@ -79,17 +80,17 @@ const Carousel: React.FC<CarouselProps> = ({ images, transitionTime }) => {
         setCurBanner(images.length);
         setTimeout(() => {
           setStartX(null);
-        }, 0);
+        }, 10);
         //TODO: remove magic number
-      }, 400);
+      }, cssTransitionTime);
     } else if (curBanner === images.length + 1) {
       setTimeout(() => {
         setStartX(1);
         setCurBanner(1);
         setTimeout(() => {
           setStartX(null);
-        }, 0);
-      }, 400);
+        }, 10);
+      }, cssTransitionTime);
     }
     translateBanner(curBanner);
 
@@ -122,7 +123,9 @@ const Carousel: React.FC<CarouselProps> = ({ images, transitionTime }) => {
   const lastBanner = images[images.length - 1];
 
   return (
-    <CarouselBlock isDragging={startX !== null} transitionTime={400}>
+    <CarouselBlock
+      isDragging={startX !== null}
+      transitionTime={cssTransitionTime}>
       <div
         className="wrapper"
         ref={containerRef}

--- a/client/src/components/Carousel/Carousel.tsx
+++ b/client/src/components/Carousel/Carousel.tsx
@@ -53,6 +53,7 @@ type CarouselProps = {
   transitionTime: number;
 };
 
+// TODO: refactor
 const Carousel: React.FC<CarouselProps> = ({ images, transitionTime }) => {
   // to get width of the container
   const containerRef = useRef<HTMLDivElement>(null);
@@ -76,20 +77,27 @@ const Carousel: React.FC<CarouselProps> = ({ images, transitionTime }) => {
     )}px)`;
   };
 
+  const createTimer = (fn: Function, timeout: number) => {
+    const timerId = setTimeout(fn, timeout);
+    setTimeoutId(timerId);
+  };
+
+  const removeTimeer = () => {
+    if (timeoutId !== null) {
+      clearTimeout(timeoutId);
+      setTimeoutId(null);
+    }
+  };
+
+  const checkEdgeCase = (idx: number) => idx === 0 || idx === images.length + 1;
   const moveBanner = (idx: number, instantMove: boolean = false) => {
-    if (idx === 0) {
+    if (checkEdgeCase(idx)) {
       setTimeout(() => {
         // To remove transition animation
         setStartX(1);
-        moveBanner(images.length, true);
-        (window as any).requestIdleCallback(() => {
-          setStartX(null);
-        });
-      }, cssTransitionTime);
-    } else if (idx === images.length + 1) {
-      setTimeout(() => {
-        setStartX(1);
-        moveBanner(1, true);
+        // 0 if idx === images.length; 1 if idx === images.length+1
+        const nextIdx = idx === 0 ? images.length : 1;
+        moveBanner(nextIdx, true);
         (window as any).requestIdleCallback(() => {
           setStartX(null);
         });
@@ -97,21 +105,13 @@ const Carousel: React.FC<CarouselProps> = ({ images, transitionTime }) => {
     }
     translateBanner(idx);
 
-    if (timeoutId !== null) {
-      clearTimeout(timeoutId);
-      setTimeoutId(null);
-    }
-
+    removeTimeer();
     setTimeout(
       () => {
         // To update indicator
         setCurBannerIdx(idx);
         if (idx > 0 && idx < images.length + 1) {
-          const newTimeoutId = setTimeout(
-            () => moveBanner(idx + 1),
-            transitionTime
-          );
-          setTimeoutId(newTimeoutId);
+          createTimer(() => moveBanner(idx + 1), transitionTime);
         }
       },
       instantMove ? 0 : cssTransitionTime

--- a/client/src/components/Carousel/Carousel.tsx
+++ b/client/src/components/Carousel/Carousel.tsx
@@ -55,14 +55,14 @@ type CarouselProps = {
 
 const Carousel: React.FC<CarouselProps> = ({ images, transitionTime }) => {
   // to get width of the container
-  const containerRef = useRef(null);
+  const containerRef = useRef<HTMLDivElement>(null);
   const cssTransitionTime = Math.min(transitionTime / 3, 400);
 
   const [curBannerIdx, setCurBannerIdx] = useState(1);
   const [timeoutId, setTimeoutId] = useState<number | null>(null);
 
   // 마우스로 화면을 눌렀을 때의 X좌표
-  const [startX, setStartX] = useState<number | null>(null);
+  const [startX, setStartX] = useState<number | null>(1);
 
   // offsetIdx번째 아이템에서 dx만큼 더 translate
   // Carousel을 이동시킬때 사용
@@ -113,8 +113,15 @@ const Carousel: React.FC<CarouselProps> = ({ images, transitionTime }) => {
 
   useEffect(() => {
     moveBanner(curBannerIdx);
+    (window as any).requestIdleCallback(() => {
+      setStartX(null);
+    });
     // eslint-disable-next-line
   }, []);
+  useEffect(() => {
+    addEventListener();
+    return removeEventListenr;
+  });
 
   const dragStartHandler = (evt: any) => {
     setStartX(evt.clientX);
@@ -134,18 +141,25 @@ const Carousel: React.FC<CarouselProps> = ({ images, transitionTime }) => {
     setStartX(null);
   };
 
+  const addEventListener = () => {
+    containerRef.current!.addEventListener('pointerdown', dragStartHandler);
+    containerRef.current!.addEventListener('pointermove', dragMoveHandler);
+    containerRef.current!.addEventListener('pointerup', dragEndHandler);
+  };
+
+  const removeEventListenr = () => {
+    containerRef.current!.removeEventListener('pointerdown', dragStartHandler);
+    containerRef.current!.removeEventListener('pointermove', dragMoveHandler);
+    containerRef.current!.removeEventListener('pointerup', dragEndHandler);
+  };
+
   const lastBanner = images[images.length - 1];
 
   return (
     <CarouselBlock
       isDragging={startX !== null}
       transitionTime={cssTransitionTime}>
-      <div
-        className="wrapper"
-        ref={containerRef}
-        onPointerDown={dragStartHandler}
-        onPointerMove={dragMoveHandler}
-        onPointerUp={dragEndHandler}>
+      <div className="wrapper" ref={containerRef}>
         <div>
           <Link to={lastBanner.routeUrl}>
             <img src={lastBanner.imageUrl} alt={lastBanner.altString}></img>

--- a/client/src/components/MainPageCategories/MainPageCategories.tsx
+++ b/client/src/components/MainPageCategories/MainPageCategories.tsx
@@ -37,7 +37,7 @@ const MainPageCategories: React.FC = () => {
   return (
     <MainPageCategoriesBlock>
       {dummyIcons.map((item) => {
-        return <CategoryIconButton {...item} />;
+        return <CategoryIconButton key={item.name} {...item} />;
       })}
     </MainPageCategoriesBlock>
   );


### PR DESCRIPTION
## 설명
- requestIdleCallback을 이용해 매직넘버 제거
- Fix edge case timing issue
  - 마지막 아이템에서 다음으로 넘어갈 때 눈속임으로 transition animation을 없애고 translate를 한 후 다시 애니매이션을 추가했는데 이 때 애니매이션이 끝난 후에 순간이동 시키고 다시 애니매이션을 추가해야 했다.
  - 따라서 setTimeout을 두번 써야 했다.(순간이동, 애니매이션 다시 추가)
  - 순간이동은 애니매이션 시간을 props로 받아서 그 시간 후에 순간이동하면 되었다.
  - 애니매이션을 다시 추가하는 것은 순간이동이 끝난 후에 추가해야했는데 원래는 setTimeout(...,0)으로 해놨었다.
  - 이를 requestIdleCallback을 이용해 순간이동이 끝난 후에 콜백함수를 실행하도록 했다.
- 리팩터를 조금 하였으나 아직도 복잡합니다.

## 관련 이슈
- resolved #63 
