### PR TITLE
이미지 lazy loading, 장바구니 카운터 스타일링

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 
 import { Switch, Route } from 'react-router-dom';
 import { gql } from 'apollo-boost';
-import { useQuery } from 'react-apollo';
+import { useLazyQuery } from 'react-apollo';
 
 import CartPage from './pages/CartPage';
 import MainPage from './pages/MainPage';
@@ -19,6 +19,7 @@ import SearchResultPage from './pages/SearchResultPage';
 
 import CategoryDetailPage from './pages/CategoryDetailPage';
 import { useCartDispatch } from './stores/cart-store';
+import useUser from './hooks/useUser';
 
 const AppBlock = styled.div`
   max-width: 100%;
@@ -32,7 +33,8 @@ const AppBlock = styled.div`
 `;
 
 function App() {
-  const { data: cartData } = useQuery(gql`
+  const user = useUser();
+  const [fetchCart, { data: cartData }] = useLazyQuery(gql`
     query {
       cart {
         id
@@ -55,6 +57,8 @@ function App() {
   useEffect(() => {
     if (cartData) cartDispatch({ type: 'INIT', payload: cartData.cart });
   }, [cartData, cartDispatch]);
+
+  if (user) fetchCart();
 
   return (
     <AppBlock>

--- a/client/src/components/Carousel/Carousel.tsx
+++ b/client/src/components/Carousel/Carousel.tsx
@@ -173,21 +173,27 @@ const Carousel: React.FC<CarouselProps> = ({ images, transitionTime }) => {
       <div className="wrapper" ref={containerRef}>
         <div>
           <Link to={lastBanner.routeUrl}>
-            <img src={lastBanner.imgUrl} alt={lastBanner.altString}></img>
+            <img
+              src={lastBanner.imgUrl}
+              alt={lastBanner.altString}
+              loading="lazy"></img>
           </Link>
         </div>
         {images.map(({ imgUrl, altString, routeUrl }, idx) => {
           return (
             <div key={idx}>
               <Link to={routeUrl}>
-                <img src={imgUrl} alt={altString}></img>
+                <img src={imgUrl} alt={altString} loading="lazy"></img>
               </Link>
             </div>
           );
         })}
         <div>
           <Link to={images[0].routeUrl}>
-            <img src={images[0].imgUrl} alt={images[0].altString}></img>
+            <img
+              src={images[0].imgUrl}
+              alt={images[0].altString}
+              loading="lazy"></img>
           </Link>
         </div>
       </div>

--- a/client/src/components/Carousel/Carousel.tsx
+++ b/client/src/components/Carousel/Carousel.tsx
@@ -99,9 +99,14 @@ const Carousel: React.FC<CarouselProps> = ({ images, transitionTime }) => {
         // 0 if idx === images.length; 1 if idx === images.length+1
         const nextIdx = idx === 0 ? images.length : 1;
         moveBanner(nextIdx, true);
-        (window as any).requestIdleCallback(() => {
-          setStartX(null);
-        });
+        if ('requestIdleCallback' in window)
+          (window as any).requestIdleCallback(() => {
+            setStartX(null);
+          });
+        else
+          setTimeout(() => {
+            setStartX(null);
+          }, cssTransitionTime);
       }, cssTransitionTime);
     }
     translateBanner(idx);
@@ -121,9 +126,14 @@ const Carousel: React.FC<CarouselProps> = ({ images, transitionTime }) => {
 
   useEffect(() => {
     moveBanner(curBannerIdx);
-    (window as any).requestIdleCallback(() => {
-      setStartX(null);
-    });
+    if ('requestIdleCallback' in window)
+      (window as any).requestIdleCallback(() => {
+        setStartX(null);
+      });
+    else
+      setTimeout(() => {
+        setStartX(null);
+      }, cssTransitionTime);
     // eslint-disable-next-line
   }, []);
   useEffect(() => {

--- a/client/src/components/Footer.tsx
+++ b/client/src/components/Footer.tsx
@@ -22,6 +22,20 @@ const FooterBlock = styled.div`
     list-style: none;
     display: grid;
     grid-template-columns: repeat(5, 1fr);
+    li {
+      position: relative;
+    }
+  }
+
+  .cart-count-indicator {
+    position: absolute;
+    top: 0.1rem;
+    right: 0.5rem;
+    background: #77d6d3;
+    width: 1.3rem;
+    height: 1.3rem;
+    border-radius: 50%;
+    text-align: center;
   }
 `;
 
@@ -70,7 +84,11 @@ const Footer: React.FC<FooterProps> = () => {
         <li>
           <LinkBlock to="/cart">
             <AddShoppingCartIcon></AddShoppingCartIcon>
-            <div>장바구니 {cart.length} 개</div>
+            <div>
+              {/* 장바구니<div hidden={cart.length === 0}>{cart.length} 개</div> */}
+              장바구니
+              <div className="cart-count-indicator">{cart.length}</div>
+            </div>
           </LinkBlock>
         </li>
       </ol>

--- a/client/src/components/Footer.tsx
+++ b/client/src/components/Footer.tsx
@@ -85,9 +85,10 @@ const Footer: React.FC<FooterProps> = () => {
           <LinkBlock to="/cart">
             <AddShoppingCartIcon></AddShoppingCartIcon>
             <div>
-              {/* 장바구니<div hidden={cart.length === 0}>{cart.length} 개</div> */}
               장바구니
-              <div className="cart-count-indicator">{cart.length}</div>
+              <div className="cart-count-indicator" hidden={cart.length === 0}>
+                {cart.length}
+              </div>
             </div>
           </LinkBlock>
         </li>

--- a/client/src/components/main/ProductFlashDiscount/ProductDiscount.js
+++ b/client/src/components/main/ProductFlashDiscount/ProductDiscount.js
@@ -39,7 +39,11 @@ const ProductDiscountBlock = styled.div`
 function ProductDiscount({ url, discount }) {
   return (
     <ProductDiscountBlock>
-      <img alt="Thumbnail" className={'Thumbnail'} src={url}></img>
+      <img
+        alt="Thumbnail"
+        className={'Thumbnail'}
+        src={url}
+        loading="lazy"></img>
       <div className="DiscountRage">
         <div>{discount}%</div> <div>할인</div>
       </div>

--- a/client/src/components/main/common/ProductPhoto.js
+++ b/client/src/components/main/common/ProductPhoto.js
@@ -30,6 +30,7 @@ function ProductPhoto({ wishbutton, onClick, index, url, select = -1 }) {
   return (
     <ProductPhotoBlock className={select === index ? ' active' : ''}>
       <img
+        loading="lazy"
         alt="Thunbnail"
         className={'Thumbnail'}
         src={url}


### PR DESCRIPTION
## 설명
- 메인 페이지의 이미지에 lazy loading 적용
- 장바구니 카운터는 장바구니에 아이템이 있을 때만 보입니다. (아래 이미지는 스타일 예시용)
- 장바구니 카운터 스타일링

## 관련 이슈
- resolved #130 
- resolved #131

## 기타(스크린샷 등)
![image](https://user-images.githubusercontent.com/8086328/91374777-ed563180-e853-11ea-897f-132431d46f24.png)
