### PR TITLE
feat: graphql 쿼리를 뭉쳐서 보내기

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -19,6 +19,7 @@
     "@types/react-router-dom": "^5.1.5",
     "@types/styled-components": "^5.1.2",
     "apollo-boost": "^0.4.9",
+    "apollo-link-batch-http": "^1.2.14",
     "axios": "^0.20.0",
     "date-fns": "^2.15.0",
     "graphql": "^15.3.0",

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -1,17 +1,17 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+import { BrowserRouter } from 'react-router-dom';
+import { ApolloProvider } from 'react-apollo';
+import { ApolloClient, InMemoryCache } from '@apollo/client';
+import { setContext } from '@apollo/client/link/context';
+import { BatchHttpLink } from 'apollo-link-batch-http';
+
+import * as serviceWorker from './serviceWorker';
+import { CartProvider } from './stores/cart-store';
 import './index.css';
 import App from './App';
-import * as serviceWorker from './serviceWorker';
-import { BrowserRouter } from 'react-router-dom';
-import { CartProvider } from './stores/cart-store';
-import { ApolloProvider } from 'react-apollo';
-import { ApolloClient, createHttpLink, InMemoryCache } from '@apollo/client';
-import { setContext } from '@apollo/client/link/context';
 
-const httpLink = createHttpLink({
-  uri: '/graphql',
-});
+const httpLink = new BatchHttpLink({ uri: '/graphql' }) as any;
 
 const authLink = setContext((_, { headers }) => {
   const token = localStorage.getItem('token');

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -2404,6 +2404,24 @@ apollo-client@^2.6.10:
     tslib "^1.10.0"
     zen-observable "^0.8.0"
 
+apollo-link-batch-http@^1.2.14:
+  version "1.2.14"
+  resolved "https://registry.yarnpkg.com/apollo-link-batch-http/-/apollo-link-batch-http-1.2.14.tgz#4502109d3f32a94d88eabd3a89274ae3a6e2f56f"
+  integrity sha512-LFUmfV3OXR3Er+zSgFxPY/qUe4Wyx0HS1euJZ36RCCaDvPegr24C9OQgKFScHy91VbjRTtFUyjXXVq1xFGPMvQ==
+  dependencies:
+    apollo-link "^1.2.14"
+    apollo-link-batch "^1.1.15"
+    apollo-link-http-common "^0.2.16"
+    tslib "^1.9.3"
+
+apollo-link-batch@^1.1.15:
+  version "1.1.15"
+  resolved "https://registry.yarnpkg.com/apollo-link-batch/-/apollo-link-batch-1.1.15.tgz#3a5b8c7d9cf1b7840ce630238249b95070e75e54"
+  integrity sha512-XbfQI/FNxJW9RSgJTfAl7RDFxxN77425yDtT7YgsImH4/2NQ+U4SWN6thWE3ZU1Wf7ktXd+XFa3KkenBRTybOQ==
+  dependencies:
+    apollo-link "^1.2.14"
+    tslib "^1.9.3"
+
 apollo-link-error@^1.0.3:
   version "1.1.13"
   resolved "https://registry.yarnpkg.com/apollo-link-error/-/apollo-link-error-1.1.13.tgz#c1a1bb876ffe380802c8df0506a32c33aad284cd"


### PR DESCRIPTION
- GraphQL link를 BatchHttpLink로 바꾸었습니다.
- 메인페이지에서 불러오던 수 많은 쿼리가 두개로 줄었습니다.

## 설명

## 기타(스크린샷 등)
