### PR TITLE
Revert "fix: 빠진 폰트 추가"

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -22,8 +22,6 @@ import { useCartDispatch } from './stores/cart-store';
 import useUser from './hooks/useUser';
 
 const AppBlock = styled.div`
-  @import url('https://fonts.googleapis.com/css2?family=Gugi&display=swap');
-  scroll-behavior: smooth;
   max-width: 100%;
   text-align: center;
   display: flex;

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -22,6 +22,7 @@ import { useCartDispatch } from './stores/cart-store';
 import useUser from './hooks/useUser';
 
 const AppBlock = styled.div`
+  scroll-behavior: smooth;
   max-width: 100%;
   text-align: center;
   display: flex;


### PR DESCRIPTION
This reverts commit 9520d0035b1809ca392b4f24f026d963edc659a2.

## 설명
- Gugi font를 App.css에서 import하고 있습니다.
- 웬지 모르겠는데(같은 webfont를 두군데 import해서 그런지) CRA dev server에서는 잘 랜더링되는데 build했을 때 아래 사진처럼 스타일이 적용되지 않습니다.

## 기타(스크린샷 등)
![image](https://user-images.githubusercontent.com/8086328/91463967-fe8c5600-e8c6-11ea-8526-9cb65368632e.png)
